### PR TITLE
Threshold bug

### DIFF
--- a/lib/vela.ex
+++ b/lib/vela.ex
@@ -439,7 +439,10 @@ defmodule Vela do
   defp within_threshold?({min, max}, threshold, compare_by) do
     [min, max] = Enum.map([min, max], compare_by)
     band = max - min
-    &(compare_by.(&1) >= min - band * threshold && compare_by.(&1) <= max + band * threshold)
+    min_threshold = if band > 0, do: min - band * threshold, else: min * ((100 - threshold) / 100)
+    max_threshold = if band > 0, do: max + band * threshold, else: max * ((100 + threshold) / 100)
+
+    &(compare_by.(&1) >= min_threshold && compare_by.(&1) <= max_threshold)
   end
 
   defmodule Stubs do

--- a/test/vela_test.exs
+++ b/test/vela_test.exs
@@ -133,6 +133,10 @@ defmodule VelaTest do
   end
 
   test "threshold" do
+    vela = put_in(%Struct2{integers: []}, [:integers], 1000)
+    assert %Struct2{integers: [1000]} = vela
+    assert %Struct2{integers: [1000, 1001]} = put_in(vela, [:integers], 1001)
+
     vela = %Struct2{integers: [1, 3]}
 
     assert %Struct2{integers: [1, 3, 4]} = put_in(vela, [:integers], 4)


### PR DESCRIPTION
The threshold calculation was not working properly. When starting from an empty series one could only insert elements containing exactly the same value.